### PR TITLE
Add support for ignoring package source location (fixes issue #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,6 @@ frustratingly fetch from the network ignoring your archives.)
 If you have unwanted modules, you can either update your `npm-shrinkwrap.json` file (run `npm
 shrinkwrap --dev`), or you can delete unwanted packages from `node_modules/`. You can suppress the
 output of unwanted modules with `--no-unwanted` option.
+
+With `--no-from`, only the version is considered when comparing `npm-shrinkwrap.json` and the
+installed module. This means that a package that comes from a different source will be accepted.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -14,6 +14,7 @@ commander
 .option("-v, --all", "Print all modules, not only the problem ones", false)
 .option("--no-unwanted", "Ignore node_modules not listed in npm-shrinkwrap.json", false)
 .option("--install", "Automatically run 'npm install --no-save' for all missing modules", false)
+.option("--no-from", "Ignores differences between package sources", false)
 .option("--no-color", "Suppress color output even when the output is to a TTY", false)
 .parse(process.argv);
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -27,11 +27,7 @@ function isRegistrySpecifier(npmSpec) {
  * Returns {spec, desc} object, where spec is to use with 'npm install', and desc is a
  * human-friendly description of the package's version.
  */
-function getInstallSpec(log, name, version, from, ignoreFrom) {
-  if (ignoreFrom === true) {
-    return {spec: version, desc: version};
-  }
-
+function getInstallSpec(log, name, version, from) {
   // If 'from' indicates that the the package doesn't come from the registry, use 'from'.
   if (from) {
     try {
@@ -89,8 +85,8 @@ function main(options) {
     let module = JSON.parse(data);
     for (let name in module.dependencies) {
       let values = module.dependencies[name];
-      const ignoreFrom = options.from === false;
-      getInfo(allModules, name).want = getInstallSpec(log, name, values.version, values.from, ignoreFrom);
+      let from = options.from !== false ? values.from : null;
+      getInfo(allModules, name).want = getInstallSpec(log, name, values.version, from);
     }
     return fs.readdirAsync(path.join(chdir, 'node_modules'));
   })
@@ -105,8 +101,8 @@ function main(options) {
     return fs.readFileAsync(path.join(chdir, 'node_modules', name, 'package.json'))
     .then(data => {
       let values = JSON.parse(data);
-      const ignoreFrom = options.from === false;
-      getInfo(allModules, name).have = getInstallSpec(log, name, values.version, values._from, ignoreFrom);
+      let from = options.from !== false ? values._from : null;
+      getInfo(allModules, name).have = getInstallSpec(log, name, values.version, from);
     })
     .catch(err => {
       // Nothing to do; this module will be missing from actualModules.

--- a/lib/main.js
+++ b/lib/main.js
@@ -27,13 +27,17 @@ function isRegistrySpecifier(npmSpec) {
  * Returns {spec, desc} object, where spec is to use with 'npm install', and desc is a
  * human-friendly description of the package's version.
  */
-function getInstallSpec(log, name, version, from) {
+function getInstallSpec(log, name, version, from, ignoreFrom) {
   // If 'from' indicates that the the package doesn't come from the registry, use 'from'.
   if (from) {
     try {
       let spec = npa(from);
       if (!isRegistrySpecifier(spec)) {
-        return {spec: from, desc: `${version} (${from})`};
+        if (ignoreFrom === true) {
+          return {spec: version, desc: version};
+        } else {
+          return {spec: from, desc: `${version} (${from})`};
+        }
       }
     } catch (e) {
       log(console.red(`${name}: can't parse version: ${from}`));
@@ -61,6 +65,7 @@ function runCmd(cmd, args) {
  * @param {Boolean} options.all: Print all modules, not only the problem ones.
  * @param {Boolean} options.unwanted: Print unwanted modules too.
  * @param {Boolean} options.install: Automatically run 'npm install' for all missing modules.
+ * @param {Boolean} options.from: Check that target source matches destination source.
  * The following are mainly for the unittests.
  * @param {Function} options.log: Function to log instead of console.log.
  * @param {Function} options.run: Function to run npm install, instead of `runCmd()`, called as
@@ -84,7 +89,8 @@ function main(options) {
     let module = JSON.parse(data);
     for (let name in module.dependencies) {
       let values = module.dependencies[name];
-      getInfo(allModules, name).want = getInstallSpec(log, name, values.version, values.from);
+      const ignoreFrom = options.from === false;
+      getInfo(allModules, name).want = getInstallSpec(log, name, values.version, values.from, ignoreFrom);
     }
     return fs.readdirAsync(path.join(chdir, 'node_modules'));
   })
@@ -99,7 +105,8 @@ function main(options) {
     return fs.readFileAsync(path.join(chdir, 'node_modules', name, 'package.json'))
     .then(data => {
       let values = JSON.parse(data);
-      getInfo(allModules, name).have = getInstallSpec(log, name, values.version, values._from);
+      const ignoreFrom = options.from === false;
+      getInfo(allModules, name).have = getInstallSpec(log, name, values.version, values._from, ignoreFrom);
     })
     .catch(err => {
       // Nothing to do; this module will be missing from actualModules.

--- a/lib/main.js
+++ b/lib/main.js
@@ -28,16 +28,16 @@ function isRegistrySpecifier(npmSpec) {
  * human-friendly description of the package's version.
  */
 function getInstallSpec(log, name, version, from, ignoreFrom) {
+  if (ignoreFrom === true) {
+    return {spec: version, desc: version};
+  }
+
   // If 'from' indicates that the the package doesn't come from the registry, use 'from'.
   if (from) {
     try {
       let spec = npa(from);
       if (!isRegistrySpecifier(spec)) {
-        if (ignoreFrom === true) {
-          return {spec: version, desc: version};
-        } else {
-          return {spec: from, desc: `${version} (${from})`};
-        }
+        return {spec: from, desc: `${version} (${from})`};
       }
     } catch (e) {
       log(console.red(`${name}: can't parse version: ${from}`));

--- a/test/fixtures/case-bad/node_modules/missing-from/package.json
+++ b/test/fixtures/case-bad/node_modules/missing-from/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "missing-from",
+  "version": "3.14.15",
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/test/fixtures/case-bad/npm-shrinkwrap.json
+++ b/test/fixtures/case-bad/npm-shrinkwrap.json
@@ -25,6 +25,10 @@
     },
     "foo/baz": {
       "version": "2.2.2"
+    },
+    "missing-from": {
+      "from": "git+https://github.com/foo/missing-from.git#abcdef1234567890",
+      "version": "3.14.15"
     }
   }
 }

--- a/test/test_main.js
+++ b/test/test_main.js
@@ -42,6 +42,7 @@ describe("main", function() {
         "✗ colors: 1.1.2 should be 1.1.1",
         "✗ foo/baz: 2.2.2 is missing",
         "✗ hello: 3.3.3 (git+https://github.com/foo/hello.git#abcdef1234567890) is missing",
+        "✗ missing-from: 3.14.15 should be 3.14.15 (git+https://github.com/foo/missing-from.git#abcdef1234567890)",
         "✗ world: 4.4.4 (./somewhere) should be 4.4.4 (git+https://github.com/foo/world.git#abcdef1234567890)",
       ]);
       messages = [];
@@ -64,6 +65,7 @@ describe("main", function() {
         "✓ foo/bar: 1.0.1 matches",
         "✗ foo/baz: 2.2.2 is missing",
         "✗ hello: 3.3.3 (git+https://github.com/foo/hello.git#abcdef1234567890) is missing",
+        "✗ missing-from: 3.14.15 should be 3.14.15 (git+https://github.com/foo/missing-from.git#abcdef1234567890)",
         "✗ world: 4.4.4 (./somewhere) should be 4.4.4 (git+https://github.com/foo/world.git#abcdef1234567890)",
       ]);
       messages = [];
@@ -88,6 +90,7 @@ describe("main", function() {
         "✗ colors: 1.1.2 should be 1.1.1",
         "✗ foo/baz: 2.2.2 is missing",
         "✗ hello: 3.3.3 (git+https://github.com/foo/hello.git#abcdef1234567890) is missing",
+        "✗ missing-from: 3.14.15 should be 3.14.15 (git+https://github.com/foo/missing-from.git#abcdef1234567890)",
         "✗ world: 4.4.4 (./somewhere) should be 4.4.4 (git+https://github.com/foo/world.git#abcdef1234567890)",
       ]);
       messages = [];
@@ -117,7 +120,7 @@ describe("main", function() {
     });
   });
 
-  it("should --no-from option works with --all", function() {
+  it("should respect both --no-from and --all", function() {
     return main({chdir: caseBad, all: true, unwanted: false, from: false, log: collect})
     .then(success => {
       assert.isFalse(success);
@@ -127,6 +130,7 @@ describe("main", function() {
         "✓ foo/bar: 1.0.1 matches",
         "✗ foo/baz: 2.2.2 is missing",
         "✗ hello: 3.3.3 is missing",
+        "✓ missing-from: 3.14.15 matches",
         "✓ world: 4.4.4 matches",
       ]);
       messages = [];
@@ -148,12 +152,14 @@ describe("main", function() {
         "✗ colors: 1.1.2 should be 1.1.1",
         "✗ foo/baz: 2.2.2 is missing",
         "✗ hello: 3.3.3 (git+https://github.com/foo/hello.git#abcdef1234567890) is missing",
+        "✗ missing-from: 3.14.15 should be 3.14.15 (git+https://github.com/foo/missing-from.git#abcdef1234567890)",
         "✗ world: 4.4.4 (./somewhere) should be 4.4.4 (git+https://github.com/foo/world.git#abcdef1234567890)",
-        "Running: npm install --no-save colors@1.1.1 foo/baz@2.2.2 git+https://github.com/foo/hello.git#abcdef1234567890 git+https://github.com/foo/world.git#abcdef1234567890"
+        "Running: npm install --no-save colors@1.1.1 foo/baz@2.2.2 git+https://github.com/foo/hello.git#abcdef1234567890 git+https://github.com/foo/missing-from.git#abcdef1234567890 git+https://github.com/foo/world.git#abcdef1234567890",
       ]);
       assert.deepEqual(commands, [
         ['npm', 'install', '--no-save', 'colors@1.1.1', 'foo/baz@2.2.2',
          'git+https://github.com/foo/hello.git#abcdef1234567890',
+         'git+https://github.com/foo/missing-from.git#abcdef1234567890',
          'git+https://github.com/foo/world.git#abcdef1234567890'
         ]
       ]);

--- a/test/test_main.js
+++ b/test/test_main.js
@@ -99,6 +99,45 @@ describe("main", function() {
     });
   });
 
+  it("should respect --no-from option", function() {
+    return main({chdir: caseBad, all: false, unwanted: false, from: false, log: collect})
+    .then(success => {
+      assert.isFalse(success);
+      assert.deepEqual(messages, [
+        "✗ colors: 1.1.2 should be 1.1.1",
+        "✗ foo/baz: 2.2.2 is missing",
+        "✗ hello: 3.3.3 is missing",
+      ]);
+      messages = [];
+    })
+    .then(() => main({chdir: caseGood, all: false, unwanted: false, log: collect}))
+    .then(success => {
+      assert.isTrue(success);
+      assert.deepEqual(messages, []);
+    });
+  });
+
+  it("should --no-from option works with --all", function() {
+    return main({chdir: caseBad, all: true, unwanted: false, from: false, log: collect})
+    .then(success => {
+      assert.isFalse(success);
+      assert.deepEqual(messages, [
+        "✗ colors: 1.1.2 should be 1.1.1",
+        "✓ commander: 2.9.0 matches",
+        "✓ foo/bar: 1.0.1 matches",
+        "✗ foo/baz: 2.2.2 is missing",
+        "✗ hello: 3.3.3 is missing",
+        "✓ world: 4.4.4 matches",
+      ]);
+      messages = [];
+    })
+    .then(() => main({chdir: caseGood, all: false, unwanted: false, log: collect}))
+    .then(success => {
+      assert.isTrue(success);
+      assert.deepEqual(messages, []);
+    });
+  });
+
   it("should generate correct npm install command with --install", function() {
     let commands = [];
     let run = (cmd, args) => { commands.push([cmd].concat(args)); return Promise.resolve(0); };


### PR DESCRIPTION
This commit adds support for ignoring package source location, using --no-from.

Additionally, I've upped the version to 0.0.4 (from the npm package), seeing as the master repo seems to contain old code.